### PR TITLE
Required changes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -173,13 +173,6 @@ public class Constants {
             K_FEED_FORWARD,
             kDriveKinematics,
             10);
-
-        // Setup trajectory constraints
-        public static final TrajectoryConfig kTrajectoryConfig =
-        new TrajectoryConfig(AutoConstants.K_MAX_SPEED_METERS_PER_SECOND, 
-            AutoConstants.K_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED)
-            .setKinematics(kDriveKinematics)
-            .addConstraint(kAutoVoltageConstraint);
     }
 
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -5,11 +5,9 @@
 package frc.robot;
 
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -144,6 +142,5 @@ public class Robot extends TimedRobot {
 
   @Override
   public void simulationPeriodic() {
-    m_robotContainer.getDriveTrain().simulationPeriodic();
   }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -115,10 +115,6 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
-    m_teleopCommand = m_robotContainer.getTelopCommand();
-    if (m_teleopCommand != null) {
-      m_teleopCommand.schedule();
-    }
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -34,9 +34,9 @@ public class RobotContainer {
 
     final Joystick stick = new Joystick(Constants.ControllerConstants.JOYSTICK_PORT);
     final XboxController xbox = new XboxController(Constants.ControllerConstants.XBOX_PORT);
-    public static SendableChooser<Command> m_chooser = new SendableChooser<>();
+    public SendableChooser<Command> m_chooser = new SendableChooser<>();
 
-    private static final AHRS m_ahrs = new AHRS();
+    private final AHRS m_ahrs = new AHRS();
 
     // ---------- Subsystems ----------\\
     private final DriveTrain m_driveTrain = new DriveTrain(m_ahrs, stick, xbox);
@@ -60,6 +60,8 @@ public class RobotContainer {
     // ---------- Global Toggles ----------\\
 
     public RobotContainer() {
+        m_driveTrain.setDefaultCommand(new SingleJoystickDrive(m_driveTrain, stick, xbox));
+
         configureButtonBindings();
         //Shuffleboard.getTab("Autonomous").add(m_chooser);
         //m_chooser.setDefaultOption("Nothing", new InstantCommand());
@@ -150,24 +152,11 @@ public class RobotContainer {
     }
 
     /**
-     * Command to run in Telop mode
-     * 
-     * @return the command to run in Telop
-     */
-    public Command getTelopCommand() {
-        return new SingleJoystickDrive(m_driveTrain, stick, xbox);
-    }
-
-    /**
      * Command to run in Test Mode
      * 
      * @return the command to run in Test
      */
     public Command getTestCommand() {
         return null;
-    }
-
-    public static AHRS getAhrs() {
-        return m_ahrs;
     }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,20 +1,5 @@
 package frc.robot;
 
-import frc.robot.Constants.AutoConstants;
-import frc.robot.Constants.DriveConstants;
-import frc.robot.commands.*;
-import frc.robot.libraries.*;
-import frc.robot.subsystems.*;
-import edu.wpi.first.math.controller.RamseteController;
-import edu.wpi.first.math.controller.SimpleMotorFeedforward;
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.wpilibj.*;
-import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj2.command.*;
-import edu.wpi.first.wpilibj2.command.button.JoystickButton;
-
 import java.util.HashMap;
 import java.util.List;
 
@@ -22,6 +7,22 @@ import com.kauailabs.navx.frc.AHRS;
 import com.pathplanner.lib.PathPlanner;
 import com.pathplanner.lib.PathPlannerTrajectory;
 import com.pathplanner.lib.auto.RamseteAutoBuilder;
+
+import edu.wpi.first.math.controller.RamseteController;
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import frc.robot.Constants.AutoConstants;
+import frc.robot.Constants.DriveConstants;
+import frc.robot.commands.Autonomous;
+import frc.robot.commands.SingleJoystickDrive;
+import frc.robot.subsystems.Arm;
+import frc.robot.subsystems.DriveTrain;
+import frc.robot.subsystems.USBCamera;
 
 /**
  * This class is where the bulk of the robot should be declared. Since
@@ -119,10 +120,6 @@ public class RobotContainer {
         // m_driveTrain.simulationReset(new Pose2d(1, 1, new Rotation2d()));
         // }));
 
-    }
-
-    public DriveTrain getDriveTrain() {
-        return m_driveTrain;
     }
 
     /**

--- a/src/main/java/frc/robot/commands/Autonomous.java
+++ b/src/main/java/frc/robot/commands/Autonomous.java
@@ -17,7 +17,9 @@ import edu.wpi.first.math.trajectory.TrajectoryGenerator;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants.AutoConstants;
 import frc.robot.Constants.DriveConstants;
+import frc.robot.Constants.DriveTrainConstants;
 import frc.robot.subsystems.DriveTrain;
 import static edu.wpi.first.wpilibj2.command.Commands.print;
 import static edu.wpi.first.wpilibj2.command.Commands.runOnce;
@@ -59,42 +61,35 @@ public class Autonomous extends CommandBase {
     return false;
   }
 
-  public static Trajectory getAnglTrajectory(){
-    var trajectoryOne =
-    TrajectoryGenerator.generateTrajectory(
-    new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-    List.of(),
-    new Pose2d(3, 0, Rotation2d.fromDegrees(0)),
-    new TrajectoryConfig(Units.feetToMeters(3.0), Units.feetToMeters(3.0)));
-
-    var trajectoryTwo =
-    TrajectoryGenerator.generateTrajectory(
-    new Pose2d(3, 0, Rotation2d.fromDegrees(0)),
-    List.of(new Translation2d(3, 3)),
-    new Pose2d(0, 3, Rotation2d.fromDegrees(0)),
-    new TrajectoryConfig(Units.feetToMeters(3.0), Units.feetToMeters(3.0)));
-
-    return trajectoryOne.concatenate(trajectoryTwo);
-}
-
   public Trajectory goForwardAndComeBack(){
-    TrajectoryConfig config = new TrajectoryConfig(Units.feetToMeters(3.0), Units.feetToMeters(3.0));
+    // Setup trajectory constraints
+    TrajectoryConfig trajectoryConfig =
+        new TrajectoryConfig(AutoConstants.K_MAX_SPEED_METERS_PER_SECOND, 
+            AutoConstants.K_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED)
+            .setKinematics(DriveConstants.kDriveKinematics)
+            .addConstraint(DriveConstants.kAutoVoltageConstraint);
 
     var trajectoryOne = TrajectoryGenerator.generateTrajectory(
-            new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-            List.of(),
-            new Pose2d(2, 0, Rotation2d.fromDegrees(0)),
-            DriveConstants.kTrajectoryConfig);
+        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+        List.of(),
+        new Pose2d(2, 2, Rotation2d.fromDegrees(90)),
+        trajectoryConfig);
 
+    TrajectoryConfig reverseTrajectoryConfig =
+        new TrajectoryConfig(AutoConstants.K_MAX_SPEED_METERS_PER_SECOND, 
+            AutoConstants.K_MAX_ACCELERATION_METERS_PER_SECOND_SQUARED)
+            .setKinematics(DriveConstants.kDriveKinematics)
+            .addConstraint(DriveConstants.kAutoVoltageConstraint)
+            .setReversed(true);
+    
     var trajectoryTwo = TrajectoryGenerator.generateTrajectory(
-            new Pose2d(2, 0, Rotation2d.fromDegrees(0)),
-            List.of(),
-            new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
-            DriveConstants.kTrajectoryConfig.setReversed(true));
+        new Pose2d(2, 2, Rotation2d.fromDegrees(90)),
+        List.of(),
+        new Pose2d(0, 0, Rotation2d.fromDegrees(0)),
+        reverseTrajectoryConfig);
 
     trajectoryOne = trajectoryOne.concatenate(trajectoryTwo);
 
-    this.driveTrain.resetOdometry(trajectoryOne.getInitialPose());
     return trajectoryOne;
 }
 

--- a/src/main/java/frc/robot/commands/SingleJoystickDrive.java
+++ b/src/main/java/frc/robot/commands/SingleJoystickDrive.java
@@ -30,6 +30,7 @@ public class SingleJoystickDrive extends CommandBase {
     this.stick = stick;
     this.xbox = xbox;
     // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(driveTrain);
   }
 
   /**
@@ -38,8 +39,8 @@ public class SingleJoystickDrive extends CommandBase {
   @Override
   public void execute() {
     driveTrain.singleJoystickDrive(
-        Deadzone.deadZone(stick.getY(), Constants.ControllerConstants.DEADZONE),
-        Deadzone.deadZone(stick.getZ(), Constants.ControllerConstants.DEADZONE));
+        Deadzone.deadZone(-stick.getY(), Constants.ControllerConstants.DEADZONE),
+        Deadzone.deadZone(-stick.getZ(), Constants.ControllerConstants.DEADZONE));
   }
 
   /** 


### PR DESCRIPTION
Minimum required changes:
- [Joystick input is backwards from what you might expect](https://docs.wpilib.org/en/latest/docs/software/hardware-apis/motors/wpi-drive-classes.html#axis-conventions).
  - [Y on the stick is _negative_ when pushed upward](https://docs.wpilib.org/en/stable/docs/software/basic-programming/joystick.html#joystick-class), so Y need to be inverted. You want to apply _positive_ power to the motors to make the robot go forward.
  - You'll need to double check this, but Z on the stick is _positive_ when twisted clockwise (just try it in the simulator and look at the values.) However, rotation in frc is counter-clockwise positive, so Z also has to be inverted.
- [Commands _must_ require their subsystems](https://docs.wpilib.org/en/latest/docs/software/commandbased/commands.html#getrequirements), so `SingleJoystickDrive` must require `Drivetrain`.
- `SingleJoystickDrive` should be the [default command](https://docs.wpilib.org/en/latest/docs/software/commandbased/subsystems.html#default-commands) for `Drivetrain`, it will run whenever another command is not using the subsystem.
- AHRS should not be static nor public.
- AHRS was being passed properly in the `Drivetrain` constructor, but it was also being referenced statically from `RobotContainer`.
- Odometry was being initialize, and then later the encoders were being reset without resetting odometry. There really is no reason to reset the encoders, but if you feel you must, just initialize odometry after that.
- This will need to be confirmed on your robot, but usually the _right_ side is the one that needs to be inverted. Applying positive power to the motors should make it go forward.